### PR TITLE
fix: Leap highlight are out of date

### DIFF
--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -425,9 +425,8 @@ local function generate(p, opt)
 			SneakLabelMask                   { bg = p.blossom, fg = p.blossom },
 
 			LeapMatch                        { gui = "bold,underline,nocombine" },
-			LeapLabelPrimary                 { Search , gui = "bold,nocombine" },
-			LeapLabelSecondary               { DiffText, gui = "bold,nocombine" },
-			LeapLabelSelected                { IncSearch },
+			LeapBackdrop                     { gui = "nocombine", fg = p.bg.lightness(p.bg.l + 20) },
+			LeapLabel                        { fg = p.blossom.lightness(p1.bg.l + 56).sa(80), gui = "bold" },
 
 			HopNextKey                       { fg = p.blossom, gui = "bold,underline" },
 			HopNextKey1                      { fg = p.sky, gui = "bold,underline" },

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -424,9 +424,8 @@ local function generate(p, opt)
 			SneakLabelMask                   { bg = p.blossom, fg = p.blossom },
 
 			LeapMatch                        { gui = "bold,underline,nocombine" },
-			LeapLabelPrimary                 { Search , gui = "bold,nocombine" },
-			LeapLabelSecondary               { DiffText, gui = "bold,nocombine" },
-			LeapLabelSelected                { IncSearch },
+			LeapBackdrop                     { gui = "nocombine", fg = p.bg.lightness(p.bg.l - 20) },
+			LeapLabel                        { fg = p.blossom.lightness(p1.bg.l - 46).sa(80), gui = "bold" },
 
 			HopNextKey                       { fg = p.blossom, gui = "bold,underline" },
 			HopNextKey1                      { fg = p.sky, gui = "bold,underline" },


### PR DESCRIPTION
Support for [leap](https://github.com/ggandor/leap.nvim) is broken. At some leap must have changed it's highlight group names breaking the integration. [They are currently](https://github.com/ggandor/leap.nvim/blob/c6bfb191f1161fbabace1f36f578a20ac6c7642c/doc/leap.txt#L347):
- `LeapMatch`
- `LeapLabel`
- `LeapBackdrop`

This PR does two things:
1. Update the highlight group names
2. Modify the used colors to increase the usability of leap and bringing it more to line 

The images below show screenshots for zenbones dark & light when Leap is active
![image](https://github.com/user-attachments/assets/222e7145-53c9-4f70-94a3-7ae747459faf)
![image](https://github.com/user-attachments/assets/17546836-7c46-450d-a5b5-0c0af6c3004a)


## Rationale for color change

Previously the labels used the same colors as `IncSearch` (bold white foreground over magenta background):
![image](https://github.com/user-attachments/assets/aa5eb5c5-0328-4d03-9904-3641d49cfef3). 

In my opinion this is not high contrast enough for how leap (or any other jump plugin) is used. In this kind of plugins labels are visible in practice for around 200 or 300 ms at most so you really need them to stand out. On the static picture the colors might look too strong but since they are only on the screen for a fraction of a second at a time they don't destroy the _zenbones experience_.

The new colors respect the previous hues but change the saturation and lightness. It also makes use of the `LeapBackdrop` group to further enhance readability.
