### PR TITLE
feat: add darken_ and lighten_whitespace options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [4.3.5](https://github.com/zenbones-theme/zenbones.nvim/compare/v4.3.4...v4.3.5) (2024-08-24)
 
+### Features
+
+* add low-contrast `darken_whitespace` and `lighten_whitespace` options distinct from `*_non_text`
 
 ### Bug Fixes
 

--- a/doc/zenbones.md
+++ b/doc/zenbones.md
@@ -76,8 +76,10 @@ the flavor name e.g. `g:rosebones_italic_comments`.
 | italic_comments                    | both       | `true`  | Make comments italicize.                                                  |
 | darken_comments                    | light      | `38`    | Percentage to darken comments relative to Normal bg.                      |
 | lighten_comments                   | dark       | `38`    | Percentage to lighten comments relative to Normal bg.                     |
-| darken_non_text                    | light      | `25`    | Percentage to darken \|hl-NonText\| relative to Normal bg.                |
-| lighten_non_text                   | dark       | `30`    | Percentage to lighten \|hl-NonText\| relative to Normal bg.               |
+| darken_non_text                    | light      | `40`    | Percentage to darken \|hl-NonText\| relative to Normal bg.                |
+| lighten_non_text                   | dark       | `45`    | Percentage to lighten \|hl-NonText\| relative to Normal bg.               |
+| darken_whitespace                  | light      | `10`    | Percentage to darken \|hl-Whitespace\| relative to Normal bg.                |
+| lighten_whitespace                 | dark       | `15`    | Percentage to lighten \|hl-Whitespace\| relative to Normal bg.               |
 | darken_line_nr                     | light      | `33`    | Percentage to darken \|hl-LineNr\| relative to Normal bg.                 |
 | lighten_line_nr                    | dark       | `35`    | Percentage to lighten \|hl-LineNr\| relative to Normal bg.                |
 | darken_cursor_line                 | light      | `3`     | Percentage to darken \|hl-CursorLine\| relative to Normal bg.             |

--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -106,10 +106,10 @@ local function generate(p, opt)
 			Visual          { bg = p.fg.de(18).lightness(p1.bg.l + 18) }, -- Visual mode selection
 			-- VisualNOS    { }, -- Visual mode selection when vim is "Not Owning the Selection".
 
-			NonText         { fg = p1.bg.li(opt.lighten_non_text or 30) }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
+			NonText         { fg = p1.bg.li(opt.lighten_non_text or 45) }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
 			SpecialKey      { NonText, gui = "italic" }, -- Unprintable characters: text displayed differently from what it really is.	But not 'listchars' whitespace. |hl-Whitespace|
-			Whitespace      { NonText }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
-			EndOfBuffer     { NonText }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+			Whitespace      { fg = p1.bg.li(opt.lighten_whitespace or 15) }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
+			EndOfBuffer     { Whitespace }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
 
 			WildMenu        { bg = p.blossom, fg = p1.bg }, -- current match in 'wildmenu' completion
 			Directory       { gui = "bold" }, -- directory names (and other special names in listings)

--- a/lua/zenbones/specs/init.lua
+++ b/lua/zenbones/specs/init.lua
@@ -41,6 +41,7 @@ function M.get_global_config(prefix, base_bg)
 				"darken_comments",
 				"darken_line_nr",
 				"darken_non_text",
+				"darken_whitespace",
 				"darken_cursor_line",
 			}),
 			common
@@ -54,6 +55,7 @@ function M.get_global_config(prefix, base_bg)
 				"lighten_comments",
 				"lighten_line_nr",
 				"lighten_non_text",
+				"lighten_whitespace",
 				"lighten_cursor_line",
 			}),
 			common

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -106,10 +106,10 @@ local function generate(p, opt)
 			Visual          { bg = p.fg.lightness(p1.bg.l - 8) }, -- Visual mode selection
 			-- VisualNOS    { }, -- Visual mode selection when vim is "Not Owning the Selection".
 
-			NonText         { fg = p1.bg.da(opt.darken_non_text or 25) }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
+			NonText         { fg = p1.bg.da(opt.darken_non_text or 40) }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
 			SpecialKey      { NonText, gui = "italic" }, -- Unprintable characters: text displayed differently from what it really is.	But not 'listchars' whitespace. |hl-Whitespace|
-			Whitespace      { NonText }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
-			EndOfBuffer     { NonText }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+			Whitespace      { fg = p1.bg.da(opt.darken_whitespace or 10) }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
+			EndOfBuffer     { Whitespace }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
 
 			WildMenu        { bg = p.blossom, fg = p1.bg }, -- current match in 'wildmenu' completion
 			Directory       { gui = "bold" }, -- directory names (and other special names in listings)


### PR DESCRIPTION
While most NonText elements should stand out and be clearly legible, the Whitespace elements are best viewed as low-contrast hints which do not compete with the main text. The amount of contrast needed is a matter of personal preference, so adding a new option is justified.

I've tweaked the defaults for NonText as well, since it no longer has to function in both roles, and so greater contrast improves legibility slightly.