### PR TITLE
Add randombones variants for when light / dark themes are set

### DIFF
--- a/colors/randombones_dark.lua
+++ b/colors/randombones_dark.lua
@@ -1,0 +1,26 @@
+if vim.g.colors_name then
+	vim.api.nvim_command [[highlight clear]]
+end
+
+vim.g.colors_name = "randombones_dark"
+
+local util = require "zenbones.util"
+local colorschemes = util.get_colorscheme_list()
+
+math.randomseed(os.time())
+
+local colorscheme = colorschemes[1]
+while true do
+	local index = math.random(#colorschemes)
+	colorscheme = colorschemes[index]
+	if colorscheme.background ~= "light" then
+		break
+	end
+end
+
+vim.g.randombones_colors_name = colorscheme.name
+
+vim.o.background = "dark"
+vim.g.colors_name = colorscheme.name
+
+util.apply_colorscheme()

--- a/colors/randombones_light.lua
+++ b/colors/randombones_light.lua
@@ -1,0 +1,26 @@
+if vim.g.colors_name then
+	vim.api.nvim_command [[highlight clear]]
+end
+
+vim.g.colors_name = "randombones_dark"
+
+local util = require "zenbones.util"
+local colorschemes = util.get_colorscheme_list()
+
+math.randomseed(os.time())
+
+local colorscheme = colorschemes[1]
+while true do
+	local index = math.random(#colorschemes)
+	colorscheme = colorschemes[index]
+	if colorscheme.background ~= "dark" then
+		break
+	end
+end
+
+vim.g.randombones_colors_name = colorscheme.name
+
+vim.o.background = "light"
+vim.g.colors_name = colorscheme.name
+
+util.apply_colorscheme()


### PR DESCRIPTION
I ran into some issues combining randombones with dark / light mode plugins and this is my attempt to address some of them 

the idea is if you have some type of background setter, i.e.
```
{
    "f-person/auto-dark-mode.nvim",
    opts = {
      -- your configuration comes here
      -- or leave it empty to use the default settings
      -- refer to the configuration section below
    },
    --  enabled = false,
  }
```

you could write a colorscheme config as below such that you would only pull appropriate schemes and not try to change the background itself
```
{
    "LazyVim/LazyVim",
    opts = {
      colorscheme = function()
        vim.schedule(function()
          if vim.o.background == "light" then
            vim.cmd("colorscheme randombones_light")
          else
            vim.cmd("colorscheme randombones_dark")
          end
        end)
      end,
    },
  }
```

You could achieve a similar effect by placing all of the logic in randombones, but I would guess that some folks enjoy getting light/dark at random. 