### PR TITLE
changed randombones so it now shows the name of the randomized theme

### DIFF
--- a/colors/randombones.lua
+++ b/colors/randombones.lua
@@ -2,8 +2,6 @@ if vim.g.colors_name then
 	vim.api.nvim_command [[highlight clear]]
 end
 
-vim.g.colors_name = "randombones"
-
 local util = require "zenbones.util"
 local colorschemes = util.get_colorscheme_list()
 
@@ -16,5 +14,7 @@ vim.g.randombones_colors_name = colorscheme.name
 if colorscheme.background then
 	vim.o.background = colorscheme.background
 end
+
+vim.g.colors_name = colorscheme.name
 
 util.apply_colorscheme()


### PR DESCRIPTION
this one I ended up doing on the side while making the _light/_dark variants. I kept running into themes that I liked + trying to figure out what they were, so this improved QOL for me. 

I also see it mentioned in the discussion https://github.com/zenbones-theme/zenbones.nvim/discussions/218